### PR TITLE
Fix missing pgcrypto extension

### DIFF
--- a/postgres/init.sql
+++ b/postgres/init.sql
@@ -1,3 +1,6 @@
+-- Enable pgcrypto for gen_random_uuid function
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+
 CREATE TABLE IF NOT EXISTS sessions (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     user_id VARCHAR(255),


### PR DESCRIPTION
## Summary
- enable `pgcrypto` in Postgres initialization so UUID generation works

## Testing
- `python3 -m pytest` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6848aaefc3388331897ceb371e974b1e